### PR TITLE
fix: append `-gnu` to Linux binary name in `lang_server_binary`

### DIFF
--- a/src/oxlint.rs
+++ b/src/oxlint.rs
@@ -32,7 +32,7 @@ impl OxlintExtension {
 
         let (platform, arch) = zed::current_platform();
         let bin_name = format!(
-            "@oxlint/{platform}-{arch}",
+            "@oxlint/{platform}-{arch}{linux_build}",
             platform = match platform {
                 zed::Os::Mac => "darwin",
                 zed::Os::Linux => "linux",
@@ -43,6 +43,10 @@ impl OxlintExtension {
                 zed::Architecture::X8664 => "x64",
                 _ => return Err(format!("unsupported architecture: {arch:?}")),
             },
+            linux_build = match platform {
+                zed::Os::Linux => "-gnu",
+                _ => "",
+            }
         );
         let fallback = &Path::new("./node_modules").join(format!("{bin_name}/oxc_language_server"));
         let version = zed::npm_package_latest_version(&bin_name)?;

--- a/src/oxlint.rs
+++ b/src/oxlint.rs
@@ -46,7 +46,7 @@ impl OxlintExtension {
             linux_build = match platform {
                 zed::Os::Linux => "-gnu",
                 _ => "",
-            }
+            },
         );
         let fallback = &Path::new("./node_modules").join(format!("{bin_name}/oxc_language_server"));
         let version = zed::npm_package_latest_version(&bin_name)?;


### PR DESCRIPTION
This fix resolves this error where the `oxlint_language_server` binary was not found on Linux platform:

```
Language server oxlint:

failed to spawn command. path: "/home/vladiantio/.var/app/dev.zed.Zed/data/zed/extensions/work/oxlint/node_modules/@oxlint/linux-x64/oxc_language_server", working directory: "/home/vladiantio/projects/oxlint-test", args: []
-- stderr--
```